### PR TITLE
endボタンの実装

### DIFF
--- a/msotu.js
+++ b/msotu.js
@@ -3,10 +3,12 @@ let daiceme = 0; //ダイスの目
 let t1 = 24; //ストーリー1のタスク
 let t2 = 21; //ストーリー2のタスク
 let t3 = 27; //ストーリー3のタスク
+let df = 0;
 let cf = 0; //チャンスカードを引いているか判断
 let select = 0; //選択されているストーリー
-let doing = 0;//doingにあるストーリーの数
-let amari = 0;//タスクを減らしたときのあまり
+let doing = 0; //doingにあるストーリーの数
+let amari = 0; //タスクを減らしたときのあまり
+let player = 1;
 
 //doingにあるストーリーの数を数える
 function status() {
@@ -34,8 +36,9 @@ function reset() {
 //乱数で１～６の数字を生成しdaice.numに代入。数字に合ったgifを再生
 function daice(e) {
   if (select == 0) {
-    window.alert('storyを選択してください');
-  } else if (daiceme == 0) {
+    document.getElementById("log").innerHTML = 'storyを選択してください';
+  } else if (df == 0) {
+    df=1;
     clikc();
     ring();
     status();
@@ -46,7 +49,7 @@ function daice(e) {
       let daice1 = Math.floor(Math.random() * 2) + 1;
       document.images['dice1'].src = '6d_0' + daice1 + '.gif'
       daiceme = daice + daice1;
-      window.alert("サイコロが1/3になっています");
+      document.getElementById("log").innerHTML = "サイコロが1/3になっています";
     }
     if (doing == 2) {
       let daice = Math.floor(Math.random() * 4) + 1;
@@ -55,7 +58,7 @@ function daice(e) {
       let daice1 = Math.floor(Math.random() * 4) + 1;
       document.images['dice1'].src = '6d_0' + daice1 + '.gif'
       daiceme = daice + daice1;
-      window.alert("サイコロが2/3になっています");
+      document.getElementById("log").innerHTML = "サイコロが2/3になっています";
     }
     if (doing == 1) {
       let daice = Math.floor(Math.random() * 6) + 1;
@@ -64,9 +67,10 @@ function daice(e) {
       let daice1 = Math.floor(Math.random() * 6) + 1;
       document.images['dice1'].src = '6d_0' + daice1 + '.gif'
       daiceme = daice + daice1;
+      document.getElementById("log").innerHTML = "";
     }
     if (doing == 0) {
-      window.alert("storyをDoingに移動してください");
+      document.getElementById("log").innerHTML = "storyをDoingに移動してください";
     }
 
   }
@@ -128,7 +132,6 @@ function disp1(num) {
       document.getElementById("task").innerHTML = t1;
       select = 1;
       sentaku(select);
-
     }
   }
 
@@ -137,29 +140,28 @@ function disp1(num) {
       window.alert('task1はDoneです.Doneに移動させてください');
       select = 1;
       daiceme = 0;
-      cf = 0;
-      reset();
       sentaku(select);
     } else {
       sound();
       amari = daiceme - t1;
       t1 = t1 - daiceme;
       daiceme = 0;
-      cf = 0;
       if (t1 > 0) {
         document.getElementById("task").innerHTML = t1
         select = 1;
         sentaku(select);
-        reset();
       } else {
         window.alert('お疲れ様です.task1をDoneに移動しましょう');
         document.getElementById("task").innerHTML = 0;
         select = 1;
         sentaku(select);
-        daiceme = amari;
+        status();
+        if(doing>1){
+          daiceme = amari;
       }
     }
   }
+}
   if (num == 3) {
     if (t1 <= 0) {
       window.alert('task1はDoneです');
@@ -197,25 +199,24 @@ function disp2(num) {
       select = 2;
       sentaku(select);
       daiceme = 0;
-      cf = 0;
-      reset();
     } else {
       sound();
       amari = daiceme - t2;
       t2 = t2 - daiceme;
       daiceme = 0;
-      cf = 0;
       if (t2 > 0) {
         document.getElementById("task").innerHTML = t2;
         select = 2;
         sentaku(select);
-        reset();
       } else {
         window.alert('お疲れ様です.task2をDoneに移動しましょう');
         document.getElementById("task").innerHTML = 0;
         select = 2;
         sentaku(select);
-        daiceme = amari;
+        status();
+        if(doing>1){
+          daiceme = amari;
+      }
       }
     }
   }
@@ -258,25 +259,24 @@ function disp3(num) {
       select = 3;
       sentaku(select);
       daiceme = 0;
-      cf = 0;
-      reset();
     } else {
       sound();
       amari = daiceme - t3;
       t3 = t3 - daiceme;
       daiceme = 0;
-      cf = 0;
       if (t3 > 0) {
         document.getElementById("task").innerHTML = t3;
         select = 3;
         sentaku(select);
-        reset();
       } else {
         window.alert('お疲れ様です.task3をDoneに移動してもう一度クリックしてください');
         document.getElementById("task").innerHTML = 0;
-        daiceme = amari;
         select = 3;
         sentaku(select);
+        status();
+        if(doing>1){
+          daiceme = amari;
+      }
       }
     }
   }
@@ -295,8 +295,8 @@ function disp3(num) {
 
 //チャンスカードのクリックしたときの動き
 function chance() {
-  if (daiceme == 0) {
-    window.alert('先にダイスを振りましょう');
+  if (df == 0) {
+    document.getElementById("log").innerHTML = '先にダイスを振りましょう';
   } else if (cf == 0) {
     let chance = Math.floor(Math.random() * 8) + 1;
     document.images['card'].src = "e" + chance + ".jpg"
@@ -357,4 +357,18 @@ function event(c) {
   if (c == 8) {
     daiceme = daiceme / 2;
   }
+}
+
+function end(){
+if(player==1){
+  player=2;
+  document.getElementById("player").innerHTML = 'player2の番です';
+}else{
+  player=1;
+  document.getElementById("player").innerHTML = 'player1の番です';
+}
+df=0;
+daiceme=0;
+cf=0;
+reset();
 }

--- a/start.html
+++ b/start.html
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE html>
+﻿
+<!DOCTYPE html>
 <html lang="ja">
 
 <head>
@@ -19,9 +20,10 @@
         </font>
       </p><br>
     </div>
-    <p><img id="task1" src="t1.jpg" onClick="disp1(t1a);" width="250" height="150" name="task1"></p>
-    <p><img id="task2" src="t2.jpg" onClick="disp2(t2a);" width="250" height="150"></p>
-    <p><img id="task3" src="t3.jpg" onClick="disp3(t3a);" width="250" height="150"></p>
+    <img id="task1" src="t1.jpg" onClick="disp1(t1a);" width="250" height="150" name="task1">
+    <img id="task2" src="t2.jpg" onClick="disp2(t2a);" width="250" height="150">
+    <img id="task3" src="t3.jpg" onClick="disp3(t3a);" width="250" height="150">
+
   </div>
   <div class="Doing" id=droparea2>
     <div class="dai"><br>
@@ -42,22 +44,19 @@
     </div>
   </div>
 
-
   <audio id="daicesound" preload="auto">
     <source src="daicesound.wav" type="audio/wav">
   </audio>
   <audio id="clikcsound" preload="auto">
     <source src="sound.mp3" type="audio/wav">
   </audio>
-  <span><img src="6d.gif" id="skill" class="skill" onclick="daice();" alt="" name="dice"></span>
-  <span><img src="6d.gif" id="skill1" class="skill1" onclick="daice();" alt="" name="dice1"></span>
+  <span><img src="6d.gif" id="dice" class="dice" onclick="daice();" alt="" name="dice"></span>
+  <span><img src="6d.gif" id="dice1" class="dice1" onclick="daice();" alt="" name="dice1"></span>
   <span><img src="card.png" id="card" class="card" onclick="chance();" width="300" height="200" name="card"></span>
-  <p class="sukoa">　　タスク； <span id="task">0</span></p>
-  <button type="button" name="aaa" value="aaa"
-    style=" width:400px;height:200px;position: absolute; left: 1100px; top: 910px">
-    <font size="500" color="#000000">END</font>
-  </button>
-
+  <p class="sukoa">タスク； <span id="task">0</span></p>
+  <p class="log"><span id="log">ログ</span></p>
+  <button class="end"  type="button" onclick="end();">end</button>
+  <p class="player"><span id="player">player1の番です</span></p>
   <audio id="stbgm" preload="auto" autoplay loop>
     <source src="stbgm.mp3" type="audio/mp3">
   </audio>
@@ -77,8 +76,8 @@
   let t3a = 1;
   //ドラッグ開始時の処理
 
-  task1.addEventListener("dragstart", function (evt) {
-    if (select == 1 && daiceme == 0) {
+  task1.addEventListener("dragstart", function(evt) {
+    if (select == 1 && daiceme==0) {
       //ドラッグ要素のidをdataTransferにセット
       evt.dataTransfer.setData("text/plain", evt.target.id);
       evt.stopPropagation();
@@ -86,8 +85,8 @@
   }, false);
 
 
-  task2.addEventListener("dragstart", function (evt) {
-    if (select == 2 && daiceme == 0) {
+  task2.addEventListener("dragstart", function(evt) {
+    if (select == 2 && daiceme==0) {
       //ドラッグ要素のidをdataTransferにセット
       evt.dataTransfer.setData("text/plain", evt.target.id);
       evt.stopPropagation();
@@ -95,8 +94,8 @@
   }, false);
 
 
-  task3.addEventListener("dragstart", function (evt) {
-    if (select == 3 && daiceme == 0) {
+  task3.addEventListener("dragstart", function(evt) {
+    if (select == 3 && daiceme==0) {
       //ドラッグ要素のidをdataTransferにセット
       evt.dataTransfer.setData("text/plain", evt.target.id);
       evt.stopPropagation();
@@ -105,7 +104,7 @@
 
 
   //ドロップされた時の処理task1
-  area1.addEventListener("drop", function (evt) {
+  area1.addEventListener("drop", function(evt) {
 
     //id名をdataTransferから取り出す
     let id = evt.dataTransfer.getData("text/plain");
@@ -128,15 +127,15 @@
   }, false);
 
   //２つのイベントでデフォルト動作を抑制する
-  area1.addEventListener("dragenter", function (evt) {
+  area1.addEventListener("dragenter", function(evt) {
     evt.preventDefault();
   }, false);
-  area1.addEventListener("dragover", function (evt) {
+  area1.addEventListener("dragover", function(evt) {
     evt.preventDefault();
   }, false);
 
   //ドロップされた時の処理
-  area2.addEventListener("drop", function (evt) {
+  area2.addEventListener("drop", function(evt) {
 
     //id名をdataTransferから取り出す
     let id = evt.dataTransfer.getData("text/plain");
@@ -159,16 +158,16 @@
   }, false);
 
   //２つのイベントでデフォルト動作を抑制する
-  area2.addEventListener("dragenter", function (evt) {
+  area2.addEventListener("dragenter", function(evt) {
     evt.preventDefault();
   }, false);
-  area2.addEventListener("dragover", function (evt) {
+  area2.addEventListener("dragover", function(evt) {
     evt.preventDefault();
   }, false);
 
 
   //ドロップされた時の処理
-  area3.addEventListener("drop", function (evt) {
+  area3.addEventListener("drop", function(evt) {
 
     //id名をdataTransferから取り出す
     let id = evt.dataTransfer.getData("text/plain");
@@ -191,10 +190,10 @@
   }, false);
 
   //２つのイベントでデフォルト動作を抑制する
-  area3.addEventListener("dragenter", function (evt) {
+  area3.addEventListener("dragenter", function(evt) {
     evt.preventDefault();
   }, false);
-  area3.addEventListener("dragover", function (evt) {
+  area3.addEventListener("dragover", function(evt) {
     evt.preventDefault();
   }, false);
 </script>

--- a/stposition.css
+++ b/stposition.css
@@ -1,4 +1,10 @@
+.body{
+position: relative;
+height: 100px;
+}
 
+
+/*カンバンの枠 */
 .ToDo{float: left;
      width:100%;
      height:100px;
@@ -44,100 +50,79 @@
 }
 
 
-.skill{
-  position: absolute;
-  top: 750px;
-  left: 40.5%;
-  cursor: pointer;
-}
 
-
-.skill1{
-  position: absolute;
-  top: 750px;
-  left: 50.5%;
-  cursor: pointer;
-}
-
-.card{
-  position: absolute;
-  top: 700px;
-  left: 80%;
-  cursor: pointer;
-}
-
-.sukoa{
-position: absolute;
-top: 750px;
-font-size:50px;
-}
-
-
-
-
-
-
-
-
-
-.box2{float: left;
-     width:20%;
-     height:100px;
-
-}
-
-.select{
-overflow: hidden;
-
-}
-
-.select:before,
-.selec:after{
-  content: "";
-  display: table;
-}
-
-.select:after{
-  clear: both;
-}
-
-.select{
-  zoom: 1;
-}
-
-.st{
-  position:relative;
-  top:25px;
-  left:10px;
-}
-
-.p1{
-  font-size:15pt;
-  padding-right:90px;
-}
-
-.p2{
-  font-size:15pt;
-  padding-left:150px;
-}
-
+/*カンバンの領域 */
 .ToDo{
   float: left;
   width:31%;
-  height:850px;
+  height:800px;
   background-color:#FFDDFF
 }
 
 .Doing{
   float: left;
   width:31%;
-  height:850px;
+  height:800px;
   background-color:#CCFFFF
 }
 
 .Done{
   float: left;
   width:31%;
-  height:850px;
+  height:800px;
   background-color:#DCC2FF
+}
+
+.dice{
+  position: absolute;
+  bottom: 0px;
+  left: 40.5%;
+  cursor: pointer;
+}
+
+
+.dice1{
+  position: absolute;
+ bottom: 0px;
+  left: 50.5%;
+  cursor: pointer;
+}
+
+.card{
+  position: absolute;
+  right: 45%;
+  bottom: 175px;
+  cursor: pointer;
+}
+
+.sukoa{
+position: absolute;
+bottom: 100px;
+left: 0;
+font-size:60px;
+}
+
+.log{
+position: absolute;
+left: 0;
+bottom: -10px;
+font-size:60px;
+
+}
+
+.player{
+position: absolute;
+right: 20%;
+bottom: -10px;
+font-size:60px;
+
+}
+
+.end{
+position: absolute;
+right: 0;
+bottom: 10px;
+width: 200px;
+height:100px;
+font-size:60px;
 }


### PR DESCRIPTION
endボタンの内容
・playerを切り替える
・ダイス、チャンスカードの絵柄をリセットする
・dfとcfを０に戻しダイスとチャンスカードを触れる状態に戻す

endボタン実装につき一部仕様変更
・タスクを消費したときにダイスとチャンスカードがリセットされない
その他変更点
・ダイスをdaiceme=０の時ではなくdf=0の時振れるに変更
・ストーリーが終了したとき他のストーリがDoingにあれば割り振れる、なければdaicemeを０にする